### PR TITLE
Disable treasure maps

### DIFF
--- a/paper.yml
+++ b/paper.yml
@@ -87,7 +87,7 @@ world-settings:
     per-player-mob-spawns: true
     portal-search-radius: 128
     use-vanilla-world-scoreboard-name-coloring: false
-    enable-treasure-maps: true
+    enable-treasure-maps: false
     treasure-maps-return-already-discovered: false
     experience-merge-max-value: -1
     prevent-moving-into-unloaded-chunks: true


### PR DESCRIPTION
Disable treasure maps to temporary fix server crash caused by mass chunk loading